### PR TITLE
Modify

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -14,7 +14,6 @@ typedef int64_t CAmount;
 static const CAmount BTC_2_BCX_RATE = 10000;
 
 static const CAmount COIN = 100000000 / BTC_2_BCX_RATE;
-static const CAmount CENT = 1000000 / BTC_2_BCX_RATE;
 
 
 /** No amount larger than this (in satoshi) is valid.

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -12,8 +12,8 @@
 // FIXME: Dedup with SetupDummyInputs in test/transaction_tests.cpp.
 //
 // Helper: create two dummy transactions, each with
-// two outputs.  The first has 11 and 50 CENT outputs
-// paid to a TX_PUBKEY, the second 21 and 22 CENT outputs
+// two outputs.  The first has 11 and 50 COIN outputs
+// paid to a TX_PUBKEY, the second 21 and 22 COIN outputs
 // paid to a TX_PUBKEYHASH.
 //
 static std::vector<CMutableTransaction>
@@ -31,16 +31,16 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
 
     // Create some dummy input transactions
     dummyTransactions[0].vout.resize(2);
-    dummyTransactions[0].vout[0].nValue = 11 * CENT;
+    dummyTransactions[0].vout[0].nValue = 11 * COIN;
     dummyTransactions[0].vout[0].scriptPubKey << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-    dummyTransactions[0].vout[1].nValue = 50 * CENT;
+    dummyTransactions[0].vout[1].nValue = 50 * COIN;
     dummyTransactions[0].vout[1].scriptPubKey << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
     AddCoins(coinsRet, dummyTransactions[0], 0);
 
     dummyTransactions[1].vout.resize(2);
-    dummyTransactions[1].vout[0].nValue = 21 * CENT;
+    dummyTransactions[1].vout[0].nValue = 21 * COIN;
     dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(key[2].GetPubKey().GetID());
-    dummyTransactions[1].vout[1].nValue = 22 * CENT;
+    dummyTransactions[1].vout[1].nValue = 22 * COIN;
     dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(key[3].GetPubKey().GetID());
     AddCoins(coinsRet, dummyTransactions[1], 0);
 
@@ -72,7 +72,7 @@ static void CCoinsCaching(benchmark::State& state)
     t1.vin[2].prevout.n = 1;
     t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
     t1.vout.resize(2);
-    t1.vout[0].nValue = 90 * CENT;
+    t1.vout[0].nValue = 90 * COIN;
     t1.vout[0].scriptPubKey << OP_1;
 
     // Benchmark.
@@ -80,7 +80,7 @@ static void CCoinsCaching(benchmark::State& state)
         bool success = AreInputsStandard(t1, coins);
         assert(success);
         CAmount value = coins.GetValueIn(t1);
-        assert(value == (50 + 21 + 22) * CENT);
+        assert(value == (50 + 21 + 22) * COIN);
     }
 }
 

--- a/src/fs.h
+++ b/src/fs.h
@@ -10,7 +10,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -63,7 +63,6 @@
 #include <QFontDatabase>
 #endif
 
-static fs::detail::utf8_codecvt_facet utf8;
 
 #if defined(Q_OS_MAC)
 extern double NSAppKitVersionNumber;
@@ -850,12 +849,12 @@ void setClipboard(const QString& str)
 
 fs::path qstringToBoostPath(const QString &path)
 {
-    return fs::path(path.toStdString(), utf8);
+    return fs::path(path.toStdString());
 }
 
 QString boostPathToQString(const fs::path &path)
 {
-    return QString::fromStdString(path.string(utf8));
+    return QString::fromStdString(path.string());
 }
 
 QString formatDurationStr(int secs)

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -39,6 +39,8 @@ static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.ran
 static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
 static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
 
+static constexpr CAmount CENT{1000000 / BTC_2_BCX_RATE};
+
 /** Basic testing setup.
  * This just configures logging and chain parameters.
  */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,6 +63,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#include <codecvt>
 
 #include <io.h> /* for _commit */
 #include <shlobj.h>
@@ -812,7 +813,11 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 
 void runCommand(const std::string& strCommand)
 {
-    int nErr = ::system(strCommand.c_str());
+    #ifndef WIN32
+        int nErr = ::system(strCommand.c_str());
+    #else
+        int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
+    #endif  
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -859,7 +859,11 @@ void SetupEnvironment()
     // A dummy locale is used to extract the internal default locale, used by
     // fs::path, which is then used to explicitly imbue the path.
     std::locale loc = fs::path::imbue(std::locale::classic());
+    #ifndef WIN32
     fs::path::imbue(loc);
+    #else
+    fs::path::imbue(std::locale(loc, new std::codecvt_utf8_utf16<wchar_t>()));
+    #endif
 }
 
 bool SetupNetworking()

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -48,7 +48,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         if (*p == '.')
         {
             p++;
-            int64_t nMult = CENT*10;
+            int64_t nMult = COIN / 10;
             while (isdigit(*p) && (nMult > 0))
             {
                 nUnits += nMult * (*p++ - '0');

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3355,7 +3355,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Check transactions
     bool fLastIsContractTx = false;
     for (const auto& tx : block.vtx) {
-        if (!CheckTransaction(*tx, state, false)) {
+        if (!CheckTransaction(*tx, state, true)) {
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -55,9 +55,9 @@ static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 //! -maxtxfee default
-static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN * BTC_2_BCX_RATE;
+static const CAmount DEFAULT_TRANSACTION_MAXFEE = COIN / 10 * BTC_2_BCX_RATE;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
-static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN * BTC_2_BCX_RATE;
+static const CAmount HIGH_TX_FEE_PER_KB = COIN / 100 * BTC_2_BCX_RATE;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -52,7 +52,7 @@ static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
 //! minimum recommended increment for BIP 125 replacement txs
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! target minimum change amount
-static const CAmount MIN_CHANGE = CENT * BTC_2_BCX_RATE;
+static constexpr CAmount MIN_CHANGE{COIN * BTC_2_BCX_RATE / 100};
 //! final minimum change amount after paying for fees
 static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 //! Default for -spendzeroconfchange

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -43,6 +43,11 @@ don't have test cases for.
 - When calling RPCs with lots of arguments, consider using named keyword
   arguments instead of positional arguments to make the intent of the call
   clear to readers.
+- Many of the core test framework classes such as `CBlock` and `CTransaction`
+  don't allow new attributes to be added to their objects at runtime like
+  typical Python objects allow. This helps prevent unpredictable side effects
+  from typographical errors or usage of the objects outside of their intended
+  purpose.
 
 #### RPC and P2P definitions
 
@@ -55,7 +60,7 @@ P2P messages. These can be found in the following source files:
 
 #### Using the P2P interface
 
-- `mininode.py` contains all the definitions for objects that pass
+- `messages.py` contains all the definitions for objects that pass
 over the network (`CBlock`, `CTransaction`, etc, along with the network-level
 wrappers for them, `msg_block`, `msg_tx`, etc).
 


### PR DESCRIPTION
Make fs::path::string() always return utf-8 string on Windows.
Document fixed attribute behavior in critical test framework classes.