### PR TITLE
utils: run commands using utf-8 string on Windows

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,6 +63,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#include <codecvt>
 
 #include <io.h> /* for _commit */
 #include <shlobj.h>
@@ -812,7 +813,11 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 
 void runCommand(const std::string& strCommand)
 {
-    int nErr = ::system(strCommand.c_str());
+    #ifndef WIN32
+        int nErr = ::system(strCommand.c_str());
+    #else
+        int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
+    #endif
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
 }


### PR DESCRIPTION
Use unicode string to call commans